### PR TITLE
Keep track of latest event id for reconnects

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -25,6 +25,7 @@ export default new Vuex.Store({
         character: "",
         activeMission: 1,
         currentMission: 1,
+        lastEventId: null,
     },
     getters: {
         getStepOne: state => {
@@ -121,13 +122,17 @@ export default new Vuex.Store({
         setActiveMission: (state, activeMission) => {
             state.activeMission = activeMission
         },
+        setLastEventId: (state, event) => {
+            state.lastEventId = event.id
+        },
         SOCKET_ONMESSAGE: state => {state},
         SOCKET_ONOPEN: state => {
             if (state.nickname && state.roomId) {
                 Vue.prototype.$socket.sendObj({
                     event: "Reconnect",
                     nickname: state.nickname,
-                    roomId: state.roomId
+                    roomId: state.roomId,
+                    lastMessageId: state.lastEventId
                 });                
             }
             console.log("ON OPEN")
@@ -140,7 +145,8 @@ export default new Vuex.Store({
             Vue.prototype.$socket.sendObj({
                 event: "Reconnect",
                 nickname: state.nickname,
-                roomId: state.roomId
+                roomId: state.roomId,
+                lastMessageId: state.lastEventId
             });
         }
     },

--- a/src/views/Avalon.vue
+++ b/src/views/Avalon.vue
@@ -175,6 +175,8 @@
                         store.dispatch("assassinVoteToGoodGuysWin")
                     }
                 }
+
+                store.commit('setLastEventId', msgJSON.id)
             }
         },
         mounted () {


### PR DESCRIPTION
Each event now has an `id` on it, that is unique per-event. This PR changes it so that we keep track of the last message id we received and then we use that when we send our `reconnect` message. 