### PR TITLE
No longer require all players to be ready before we advance to Mission proposal views

### DIFF
--- a/src/components/PlayerInfo.vue
+++ b/src/components/PlayerInfo.vue
@@ -95,7 +95,6 @@
 <script>
     export default {
         name: 'PlayerInfo',
-        components: {},
         methods: {
             confirmReady: function () {
                 this.$store.dispatch("stepTwoToQuestPhase");
@@ -119,9 +118,6 @@
             },
             isAssassin: function () {
                 return this.$store.state.character === "Assassin"
-            },
-            ready: function () {
-                return this.$store.state.playerInfo.ready
             }
         }
     }
@@ -275,17 +271,6 @@
 
     .readyButtonWrapper {
         margin-bottom: 5px;
-    }
-
-    .ready {
-        display: flex;
-        flex-direction: column;
-        flex: 1 1 0;
-        padding: 20px;
-        padding-bottom: 0px;
-        background-color: $incomplete;
-        color: whitesmoke;
-        font-size: 3em;
     }
 
     .backgroundGood {

--- a/src/components/PlayerInfo.vue
+++ b/src/components/PlayerInfo.vue
@@ -93,14 +93,12 @@
 </template>
 
 <script>
-    import store from "../store/index.js"
-
     export default {
         name: 'PlayerInfo',
         components: {},
         methods: {
             confirmReady: function () {
-                store.dispatch("stepTwoToQuestPhase");
+                this.$store.dispatch("stepTwoToQuestPhase");
             }
         },
         computed: {

--- a/src/components/PlayerInfo.vue
+++ b/src/components/PlayerInfo.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="wrapper">
-        <div id="playerInfo" v-if="!ready"
+        <div id="playerInfo"
              :class="{backgroundGood: isGood, backgroundBad: isBad, backgroundAssassin: isAssassin, backgroundMerlin: isMerlin}">
             <div class="knight character" v-if="isGood">
                 <div class="rolePreTextWrapper">
@@ -16,7 +16,6 @@
                 <div class="readyButtonWrapper">
                     <img class="readyButton" src="@/assets/readyButtonBig.png" v-on:click="confirmReady">
                 </div>
-                <LeaveGame class="leaveGame"/>
             </div>
 
             <div class="warlock character" v-if="isBad">
@@ -40,7 +39,6 @@
                 <div class="readyButtonWrapper">
                     <img class="readyButton" src="@/assets/readyButtonBig.png" v-on:click="confirmReady">
                 </div>
-                <LeaveGame class="leaveGame"/>
             </div>
 
             <div class="merlin character" v-if="isMerlin">
@@ -65,7 +63,6 @@
                     <img class="readyButton" src="@/assets/readyButtonBig.png"
                          v-on:click="confirmReady">
                 </div>
-                <LeaveGame class="leaveGame"/>
             </div>
 
             <div class="assassin character" v-if="isAssassin">
@@ -90,30 +87,20 @@
                     <img class="readyButton" src="@/assets/readyButtonBig.png"
                          v-on:click="confirmReady">
                 </div>
-                <LeaveGame/>
             </div>
-        </div>
-
-        <div class="ready" v-if="ready">
-            Waiting on others to ready up...
-            <LeaveGame class="leaveGameWaiting"/>
         </div>
     </div>
 </template>
 
 <script>
-    import WebsocketService from "../services/WebsocketService";
-    import LeaveGame from "./LeaveGame"
+    import store from "../store/index.js"
 
     export default {
         name: 'PlayerInfo',
-        components: {
-            LeaveGame
-        },
+        components: {},
         methods: {
             confirmReady: function () {
-                const confirmReadyObj = {event: 'PlayerReady'};
-                WebsocketService.sendObj(this.$socket, confirmReadyObj);
+                store.dispatch("stepTwoToQuestPhase");
             }
         },
         computed: {
@@ -138,31 +125,12 @@
             ready: function () {
                 return this.$store.state.playerInfo.ready
             }
-        },
-        created() {
-            this.$options.sockets.onmessage = (msg) => {
-                let msgJSON = JSON.parse(msg.data)
-
-                if (msgJSON.event === 'PlayerReadyAcknowledgement') {
-                    this.$store.state.playerInfo.ready = true
-                }
-            }
         }
     }
 </script>
 
 <style lang="scss" scoped>
     @import "../styles/variables";
-
-    .leaveGame {
-        display: flex;
-        flex: 1 1 0;
-        margin: 3% auto;
-    }
-
-    .leaveGameWaiting {
-        margin-top: 10%;
-    }
 
     .character {
         padding: 13px;

--- a/src/components/PlayerInfo.vue
+++ b/src/components/PlayerInfo.vue
@@ -14,7 +14,7 @@
                 </div>
                 <div class="badGuysTextWrapper"></div>
                 <div class="readyButtonWrapper">
-                    <img class="readyButton" src="@/assets/readyButtonBig.png" v-on:click="confirmReady">
+                    <img class="readyButton" src="@/assets/readyButtonBig.png" v-on:click="moveToFirstMission">
                 </div>
             </div>
 
@@ -37,7 +37,7 @@
                     </div>
                 </div>
                 <div class="readyButtonWrapper">
-                    <img class="readyButton" src="@/assets/readyButtonBig.png" v-on:click="confirmReady">
+                    <img class="readyButton" src="@/assets/readyButtonBig.png" v-on:click="moveToFirstMission">
                 </div>
             </div>
 
@@ -61,7 +61,7 @@
                 </div>
                 <div class="readyButtonWrapper">
                     <img class="readyButton" src="@/assets/readyButtonBig.png"
-                         v-on:click="confirmReady">
+                         v-on:click="moveToFirstMission">
                 </div>
             </div>
 
@@ -85,7 +85,7 @@
                 </div>
                 <div class="readyButtonWrapper">
                     <img class="readyButton" src="@/assets/readyButtonBig.png"
-                         v-on:click="confirmReady">
+                         v-on:click="moveToFirstMission">
                 </div>
             </div>
         </div>
@@ -96,7 +96,7 @@
     export default {
         name: 'PlayerInfo',
         methods: {
-            confirmReady: function () {
+            moveToFirstMission: function () {
                 this.$store.dispatch("stepTwoToQuestPhase");
             }
         },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -112,13 +112,23 @@ export default new Vuex.Store({
             state.gameState.playerInfo = !state.gameState.playerInfo
         },
         stepTwoToQuestPhase: ({state}) => {
-            state.gameState.playerInfo = !state.gameState.playerInfo
-            state.gameState.questInfoDisplay = !state.gameState.questInfoDisplay
-            state.gameState.proposeMissionParty = !state.gameState.proposeMissionParty
+            //This means that we're already past the ProposeMissionParty state so we jump straight to ProposedPartyVote
+            if (state.ProposedPartyVoteMenu.proposedParty.length >= 1) {
+                state.gameState.playerInfo = false
+                state.gameState.questInfoDisplay = true
+                state.gameState.proposedPartyVote = true
+            } else {
+                state.gameState.playerInfo = false
+                state.gameState.questInfoDisplay = true
+                state.gameState.proposeMissionParty = true
+            }
         },
         ToggleProposeMissionPartyAndProposedPartyVote: ({state}) => {
-            state.gameState.proposeMissionParty = !state.gameState.proposeMissionParty
-            state.gameState.proposedPartyVote = !state.gameState.proposedPartyVote
+            //If we are in PlayerInfo state we cannot move forward until the user has Ready'd up
+            if (!state.gameState.playerInfo) {
+                state.gameState.proposeMissionParty = !state.gameState.proposeMissionParty
+                state.gameState.proposedPartyVote = !state.gameState.proposedPartyVote
+            }
         },
         ProposedPartyVoteToPassFailVote: ({state}) => {
             state.gameState.proposedPartyVote = !state.gameState.proposedPartyVote

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -34,9 +34,6 @@ export default new Vuex.Store({
             badGuysWin: false,
             goodGuysWin: false,
         },
-        playerInfo: {
-            ready: false,
-        },
         assassinVote: {
             assassinVoteData: {},
         },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -121,11 +121,8 @@ export default new Vuex.Store({
             }
         },
         ToggleProposeMissionPartyAndProposedPartyVote: ({state}) => {
-            //If we are in PlayerInfo state we cannot move forward until the user has Ready'd up
-            if (!state.gameState.playerInfo) {
-                state.gameState.proposeMissionParty = !state.gameState.proposeMissionParty
-                state.gameState.proposedPartyVote = !state.gameState.proposedPartyVote
-            }
+            state.gameState.proposeMissionParty = !state.gameState.proposeMissionParty
+            state.gameState.proposedPartyVote = !state.gameState.proposedPartyVote
         },
         ProposedPartyVoteToPassFailVote: ({state}) => {
             state.gameState.proposedPartyVote = !state.gameState.proposedPartyVote

--- a/src/views/Avalon.vue
+++ b/src/views/Avalon.vue
@@ -118,7 +118,10 @@
                     }
                 } else if (msgJSON.event === 'ProposedParty') {
                     store.state.ProposedPartyVoteMenu.proposedParty = msgJSON.proposedParty
-                    store.dispatch("ToggleProposeMissionPartyAndProposedPartyVote")
+                    if (!store.state.gameState.playerInfo) {
+                        store.dispatch("ToggleProposeMissionPartyAndProposedPartyVote")
+                    }
+
                 } else if (msgJSON.event === 'PartyApproved') {
                     store.dispatch("ProposedPartyVoteToPassFailVote")
                 } else if (msgJSON.event === 'PassFailVoteResults') {

--- a/src/views/Avalon.vue
+++ b/src/views/Avalon.vue
@@ -115,8 +115,6 @@
                         store.dispatch("ToggleProposeMissionPartyAndProposedPartyVote")
                     } else if (this.displayPassFailVoteResults) {
                         store.dispatch("displayPassFailVoteResultsToProposeMissionParty")
-                    } else {
-                        store.dispatch("stepTwoToQuestPhase")
                     }
                 } else if (msgJSON.event === 'ProposedParty') {
                     store.state.ProposedPartyVoteMenu.proposedParty = msgJSON.proposedParty

--- a/tests/unit/PlayerInfo.spec.js
+++ b/tests/unit/PlayerInfo.spec.js
@@ -1,7 +1,6 @@
 import {expect} from 'chai'
 import {shallowMount} from '@vue/test-utils'
-import WebsocketService from '../../src/services/WebsocketService.js'
-import {assert, stub, restore, match} from "sinon";
+import {restore} from "sinon";
 import PlayerInfo from "../../src/components/PlayerInfo";
 import VueNativeSock from "vue-native-websocket";
 import Vuex from "vuex";
@@ -25,11 +24,16 @@ describe('PlayerInfo.vue', () => {
                     ready: false
                 },
                 badGuys: [],
-                character: ""
+                character: "",
+                stateAdvanced: false
+            },
+            actions: {
+                stepTwoToQuestPhase: ({state}) => {
+                    state.stateAdvanced = true;
+                }
             }
         })
         restore()
-        stub(WebsocketService, 'sendObj')
     })
 
     it('should display good guy info when character is NormalGoodGuy', () => {
@@ -62,7 +66,6 @@ describe('PlayerInfo.vue', () => {
     it('should display assassin info when character is Assassin', () => {
         store.state.character = "Assassin"
         wrapper = shallowMount(PlayerInfo, {store})
-
 
         const infoWrapper = wrapper.findAll('.assassin')
 
@@ -105,12 +108,12 @@ describe('PlayerInfo.vue', () => {
         expect(infoWrapper.length).to.equal(1)
     });
 
-    it('should call sendObj correctly when submitted', () => {
-        store.state.character = "NormalBadGuy"
+    it('properly advance state when we havent received a party proposal', () => {
+        store.state.character = "NormalGoodGuy"
         wrapper = shallowMount(PlayerInfo, {store})
 
         wrapper.find('.readyButton').trigger('click')
 
-        assert.calledWith(WebsocketService.sendObj, match.any, {event: 'PlayerReady'})
-    });
+        expect(store.state.stateAdvanced).to.equal(true)
+    })
 })


### PR DESCRIPTION
This allows us to remove the `LeaveGame` button from the `PlayerInfo` view, which keeps the UI looking good for that screen. It also allows us to simplify a bit of our websocket interactions with the backend. However, it does make state transitions a bit more complex, but hopefully not much more difficult to reason about. 