### PR TITLE
Send LeaveGame when you leave Lobby

### DIFF
--- a/src/components/LeaveGame.vue
+++ b/src/components/LeaveGame.vue
@@ -18,6 +18,8 @@
 </template>
 
 <script>
+    import WebsocketService from "../services/WebsocketService";
+
     export default {
         name: 'AssassinVote',
         data: function () {
@@ -27,6 +29,9 @@
         },
         methods: {
             resetToLobby: function () {
+                if (this.$store.state.gameState.lobby) {
+                    WebsocketService.sendObj(this.$socket, {"event": "LeaveGame"})
+                }
                 this.$store.commit("resetState");
             },
             toggleModalActive: function () {


### PR DESCRIPTION
We only want to send this message when we're in the Lobby - it won't work for other states as the game will already be started and unrecoverable if someone were to actually leave. This message could ultimately be changed to `LeaveLobby`, as that's probably more fitting. 